### PR TITLE
Tweaks over QLearning agent (Q7)

### DIFF
--- a/trabalho4/src/qlearningAgents.py
+++ b/trabalho4/src/qlearningAgents.py
@@ -43,7 +43,6 @@ class QLearningAgent(ReinforcementAgent):
         "You can initialize Q-values here..."
         ReinforcementAgent.__init__(self, **args)
 
-        "*** YOUR CODE HERE ***"
         self.qValues = util.Counter()
 
     def getQValue(self, state, action):
@@ -52,7 +51,6 @@ class QLearningAgent(ReinforcementAgent):
           Should return 0.0 if we have never seen a state
           or the Q node value otherwise
         """
-        "*** YOUR CODE HERE ***"
         if state == 'TERMINAL_STATE':
           return 0.0
 
@@ -67,7 +65,6 @@ class QLearningAgent(ReinforcementAgent):
           there are no legal actions, which is the case at the
           terminal state, you should return a value of 0.0.
         """
-        "*** YOUR CODE HERE ***"
         if state == 'TERMINAL_STATE':
           return 0.0
 
@@ -85,7 +82,6 @@ class QLearningAgent(ReinforcementAgent):
           are no legal actions, which is the case at the terminal state,
           you should return None.
         """
-        "*** YOUR CODE HERE ***"
         if state == 'TERMINAL_STATE':
           return None
         
@@ -116,8 +112,6 @@ class QLearningAgent(ReinforcementAgent):
         """
         # Pick Action
         legalActions = self.getLegalActions(state)
-        action = None
-        "*** YOUR CODE HERE ***"
         if util.flipCoin(self.epsilon):    
           return random.choice(legalActions)
 
@@ -132,7 +126,6 @@ class QLearningAgent(ReinforcementAgent):
           NOTE: You should never call this function,
           it will be called on your behalf
         """
-        "*** YOUR CODE HERE ***"
         qValueState = self.getQValue(state, action)
 
         self.qValues[str(state[0])+str(state[1])+action] = (1 - self.alpha) * qValueState + self.alpha * (reward + self.discount * self.getValue(nextState))

--- a/trabalho4/src/qlearningAgents.py
+++ b/trabalho4/src/qlearningAgents.py
@@ -51,10 +51,7 @@ class QLearningAgent(ReinforcementAgent):
           Should return 0.0 if we have never seen a state
           or the Q node value otherwise
         """
-        if state == 'TERMINAL_STATE':
-          return 0.0
-
-        return self.qValues[str(state[0])+str(state[1])+action]
+        return self.qValues[str(state)+action]
         
 
 
@@ -65,12 +62,11 @@ class QLearningAgent(ReinforcementAgent):
           there are no legal actions, which is the case at the
           terminal state, you should return a value of 0.0.
         """
-        if state == 'TERMINAL_STATE':
-          return 0.0
-
         actions = self.getLegalActions(state)
         stateQValues = []
 
+        if len(actions) == 0 :
+          return 0.0
         for x in range(len(actions)):
           stateQValues.append(self.getQValue(state, actions[x]))
 
@@ -82,13 +78,14 @@ class QLearningAgent(ReinforcementAgent):
           are no legal actions, which is the case at the terminal state,
           you should return None.
         """
-        if state == 'TERMINAL_STATE':
-          return None
         
         actions = self.getLegalActions(state)
         bestQValue = self.getValue(state)
         bestActions = []
         
+        if len(actions) == 0:
+          return None
+
         for x in range(len(actions)):
           if self.getQValue(state, actions[x]) == bestQValue:
             bestActions.append(actions[x])
@@ -128,7 +125,7 @@ class QLearningAgent(ReinforcementAgent):
         """
         qValueState = self.getQValue(state, action)
 
-        self.qValues[str(state[0])+str(state[1])+action] = (1 - self.alpha) * qValueState + self.alpha * (reward + self.discount * self.getValue(nextState))
+        self.qValues[str(state)+action] = (1 - self.alpha) * qValueState + self.alpha * (reward + self.discount * self.getValue(nextState))
 
     def getPolicy(self, state):
         return self.computeActionFromQValues(state)


### PR DESCRIPTION
# What does this PR do?
Causes the existing QLearning agent to pass the question 7 tests. 
What was made:
1. Changed the way qvalues are indexed, so that it is compatible with `GameState` object
2. Terminal states are states with no possible actions, therefore this is the way they are identified

# Tests
Since this is the last mandatory question, below are the print of all question's tests:
- `python3 autograder.py`
![image](https://user-images.githubusercontent.com/32987232/164785101-4575366a-727b-49e0-a68d-60f5722974cd.png)